### PR TITLE
Adding cURL if no wget on the box

### DIFF
--- a/roothelper.sh
+++ b/roothelper.sh
@@ -48,7 +48,16 @@ RHelpers['rootend.zip']="https://github.com/twelvesec/rootend/archive/master.zip
 function rh_download(){
 
     for h in "${!RHelpers[@]}"; do
-        wget -nv -O "${rh_dest}/$h" "${RHelpers[$h]}"
+        dest="${rh_dest}/$h"
+        url="${RHelpers[$h]}"
+
+	if [ -x "$(which wget)" ] ; then
+	    wget -nv -O "$dest" "$url"
+	elif [ -x "$(which curl)" ]; then
+	    curl -o "$dest" -sfL "$url"
+	else
+            echo "Could not find curl or wget."
+    fi
     done
 }
 


### PR DESCRIPTION
Added the ability to use cURL if wget is not found on the box. Saw #5 and agree that that was a poor implementation but this allows for handling of either wget or cURL. 

If the options for cURL aren't the ones that would give the desired output feel free to change them.